### PR TITLE
feat(query-api): add Count and Frequency endpoints for Profiles and P…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Revision history for Decentralized-Belt-System
 
 
+## 0.2.3.0 -- 2025-01-06
+
+### Query API Enhancements
+
+**Extended Profiles and Promotions APIs with Count and Frequency Endpoints**
+
+#### Profiles API Extensions
+- **GET /profiles/count**: Get total count of profiles with optional `profile_type` filter
+- **GET /profiles/frequency**: Get profile counts grouped by type (`Practitioner`, `Organization`)
+
+#### Promotions API Extensions  
+- **GET /promotions/count**: Get total count of promotions with optional filters (`profile`, `belt`, `achieved_by`, `awarded_by`)
+- **GET /promotions/frequency**: Get promotion counts grouped by belt type
+
+#### Implementation Details
+- Added `getProfileTypeTotals` to `Query/Projected.hs` and `Query/Live.hs`
+- Added `getPromotionBeltTotals` to `Query/Projected.hs` and `Query/Live.hs`
+- All new endpoints support `liveprojection` query flag for live blockchain vs projected database queries
+- Follows the same pattern as existing Belts API Count and Frequency endpoints
+
 ## 0.2.2.0 -- 2024-12-21
 
 ### API Architecture Split

--- a/src/exe/query-api/Query/Live.hs
+++ b/src/exe/query-api/Query/Live.hs
@@ -160,3 +160,17 @@ getBeltTotals = do
   let allBelts = Prelude.map rankBelt allRanks
   let beltTotals = toOccurList . fromList $ allBelts
   return beltTotals
+
+getProfileTypeTotals :: (MonadReader QueryAppContext m, MonadIO m) => m [(ProfileType, Int)]
+getProfileTypeTotals = do
+  allProfiles <- getProfiles Nothing Nothing Nothing
+  let allTypes = Prelude.map profileType allProfiles
+  let typeTotals = toOccurList . fromList $ allTypes
+  return typeTotals
+
+getPromotionBeltTotals :: (MonadReader QueryAppContext m, MonadIO m) => m [(BJJBelt, Int)]
+getPromotionBeltTotals = do
+  allPromotions <- getPromotions Nothing Nothing Nothing
+  let allBelts = Prelude.map promotionBelt allPromotions
+  let beltTotals = toOccurList . fromList $ allBelts
+  return beltTotals

--- a/src/exe/query-api/Query/Projected.hs
+++ b/src/exe/query-api/Query/Projected.hs
@@ -273,3 +273,25 @@ getBeltTotals = do
     let belts = Prelude.map unValue rows
     pure (toOccurList . fromList $ belts)
     ) pool
+
+getProfileTypeTotals :: (MonadIO m, MonadReader QueryAppContext m) => m [(ProfileType, Int)]
+getProfileTypeTotals = do
+  pool <- asks pgPool
+  liftIO $ runSqlPool (do
+    rows <- select $ do
+      pp <- from $ table @ProfileProjection
+      pure (pp ^. ProfileProjectionProfileType)
+    let profileTypes = Prelude.map unValue rows
+    pure (toOccurList . fromList $ profileTypes)
+    ) pool
+
+getPromotionBeltTotals :: (MonadIO m, MonadReader QueryAppContext m) => m [(BJJBelt, Int)]
+getPromotionBeltTotals = do
+  pool <- asks pgPool
+  liftIO $ runSqlPool (do
+    rows <- select $ do
+      pr <- from $ table @PromotionProjection
+      pure (pr ^. PromotionProjectionPromotionBelt)
+    let belts = Prelude.map unValue rows
+    pure (toOccurList . fromList $ belts)
+    ) pool


### PR DESCRIPTION
…romotions APIs

- Add GET /profiles/count with profile_type filter
- Add GET /profiles/frequency returning counts by ProfileType
- Add GET /promotions/count with profile, belt, achieved_by, awarded_by filters
- Add GET /promotions/frequency returning counts by BJJBelt
- Add getProfileTypeTotals to Query/Projected.hs and Query/Live.hs
- Add getPromotionBeltTotals to Query/Projected.hs and Query/Live.hs
- All endpoints support liveprojection flag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces count and frequency queries to broaden the Query API surface and align Profiles/Promotions with existing Belts metrics.
> 
> - New endpoints: `GET /profiles/count`, `GET /profiles/frequency`, `GET /promotions/count`, `GET /promotions/frequency` (all support `liveprojection`)
> - Route handlers wired in `RestAPI.hs` (`profilesServer`, `promotionsServer`) with filters for `profile_type`, `profile`, `belt`, `achieved_by`, `awarded_by`
> - Aggregations implemented in both backends:
>   - `Query/Live.hs`: `getProfileTypeTotals`, `getPromotionBeltTotals`
>   - `Query/Projected.hs`: SQL-based `getProfileTypeTotals`, `getPromotionBeltTotals`
> - CHANGELOG updated to `0.2.3.0` documenting the new Query API endpoints
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11fac4664fba758de7b16883a26f3d8c02322196. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->